### PR TITLE
Update PRINT_END macro to reduce stringing

### DIFF
--- a/cfgs/misc-macros.cfg
+++ b/cfgs/misc-macros.cfg
@@ -186,7 +186,6 @@ gcode:
 
     M400                                    ; wait for buffer to clear
     G92 E0                                  ; zero the extruder
-    G1 E-{PRE_PURGE_PRIME_LENGTH} F400      ; retract filament
     G91                                     ; relative positioning
 
     #   Set safe speeds
@@ -220,8 +219,8 @@ gcode:
         {% set z_safe = max_z - printer.toolhead.position.z %}
     {% endif %}
 
+    G0 X{x_safe} Y{y_safe} E-{PRE_PURGE_PRIME_LENGTH} F{maxVelocityAdjusted}   ; move nozzle and retract filament to remove stringing
     G0 Z{z_safe} F{zVelocityAdjusted}             ; move nozzle up
-    G0 X{x_safe} Y{y_safe} F{maxVelocityAdjusted}   ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning


### PR DESCRIPTION
Combine filament retraction with the X/Y-move, and reordered the Z-move to happen after retraction.